### PR TITLE
Add initial appwrite.template.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Appwrite related files
+appwrite.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["biomejs.biome"]
+	"recommendations": ["biomejs.biome", "yzhang.markdown-all-in-one"]
 }

--- a/README.md
+++ b/README.md
@@ -1,30 +1,43 @@
-# React + TypeScript + Vite
+# Invoice Generator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This app allows users:
 
-Currently, two official plugins are available:
+- create invoices
+- send them to clients
+- keep track of unpaid invoices
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Prerequisites
 
-## Expanding the ESLint configuration
+### Appwrite
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+1. Appwrite version 1.5 or above
+2. [Appwrite CLI](https://appwrite.io/docs/tooling/command-line/installation)
 
-- Configure the top-level `parserOptions` property like this:
+### App
 
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
-```
+1. Node version 18 or above
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+## Getting Started
+
+### Appwrite
+
+The following steps use the [Appwrite CLI](https://appwrite.io/docs/tooling/command-line/installation) to set up Appwrite.
+
+1. Create a project via the Appwrite Console and take note of the project ID
+2. Copy the `appwrite.template.json` to `appwrite.json`
+3. Replace the `<YOUR_PROJECT_ID>` placeholder with your project ID
+4. Deploy the collections:
+   1. `appwrite deploy collection --all --yes`
+5. Deploy the buckets:
+   1. `appwrite deploy bucket --all --yes`
+6. 1. Create an API Key and take note of the secret (make sure to replace `<YOUR_PROJECT_ID>` in the following command)
+   1. `appwrite projects createKey --projectId <YOUR_PROJECT_ID> --name "Functions" --scopes documents.read documents.write files.read files.write users.read users.write targets.read targets.write messages.write`
+7. Deploy the functions:
+   1. `appwrite deploy function --all --yes`
+
+### App
+
+1. Install dependencies
+   1. `npm i`
+2. Start the dev server
+   1. `npm run dev`

--- a/appwrite.template.json
+++ b/appwrite.template.json
@@ -1,0 +1,52 @@
+{
+    "projectId": "<YOUR_PROJECT_ID>",
+    "projectName": "Invoice Generator",
+    "databases": [
+        {
+            "$id": "default",
+            "name": "Default",
+            "$createdAt": "2024-03-27T15:14:53.385+00:00",
+            "$updatedAt": "2024-03-27T15:14:53.385+00:00",
+            "enabled": true
+        }
+    ],
+    "buckets": [
+        {
+            "$id": "logos",
+            "$createdAt": "2024-03-27T15:11:50.261+00:00",
+            "$updatedAt": "2024-03-27T15:13:27.893+00:00",
+            "$permissions": [
+                "create(\"users\")"
+            ],
+            "fileSecurity": true,
+            "name": "Logos",
+            "enabled": true,
+            "maximumFileSize": 1000000,
+            "allowedFileExtensions": [
+                "jpg",
+                "png",
+                "svg",
+                "gif"
+            ],
+            "compression": "zstd",
+            "encryption": false,
+            "antivirus": true
+        },
+        {
+            "$id": "invoices",
+            "$createdAt": "2024-03-27T15:13:05.354+00:00",
+            "$updatedAt": "2024-03-27T15:14:23.942+00:00",
+            "$permissions": [],
+            "fileSecurity": true,
+            "name": "Invoices",
+            "enabled": true,
+            "maximumFileSize": 5000000,
+            "allowedFileExtensions": [
+                "pdf"
+            ],
+            "compression": "zstd",
+            "encryption": true,
+            "antivirus": true
+        }
+    ]
+}

--- a/biome.json
+++ b/biome.json
@@ -8,5 +8,8 @@
 		"rules": {
 			"recommended": true
 		}
+	},
+	"files": {
+		"ignore": ["appwrite.template.json"]
 	}
 }


### PR DESCRIPTION
Developers can use this template for their appwrite.json to deploy the project.

The appwrite.json file should be ignored from git because it may contain sensitive values like function variables.

The appwrite.template.json should be ignored by biome so that it isn't reformatted, making it out of sync with the appwrite.json file.

Related:

* #8 